### PR TITLE
Added SSL/TLS practical tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Supported by: [GuardRails.io](https://www.guardrails.io)
 - [Prevent cross-site scripting (XSS) attacks](https://www.ibm.com/developerworks/library/se-prevent-cross-site-scripting-attacks/index.html) - This article explains how XSS attacks work and suggests a methodology to block XSS attacks.
 - [Java Security Resource Center](https://www.oracle.com/technetwork/java/javase/overview/security-2043272.html) - A collection of security details for different users of the Java Platform.
 
+## Practices
+
+- [Encrypting with SSL/TLS](https://github.com/Hakky54/mutual-tls-ssl) Step by step guide for encrypting client and server communication
+
 ## Specifications
 
 - [JSR 115: Java Authorization Contract for Containers](https://jcp.org/en/jsr/detail?id=115)


### PR DESCRIPTION
Added an example project which has no security.
It provides how-to steps to enable encryption with SSL/TLS for three scenarios:
- one way authentication - server communicates over https and identifies itself with a certificate
- two way authentication - both server and client needs to identify itself and trust each other
- two way authentication based on trusting the certificate authority - same as above one but trusting the root-ca is enough to get the same result

Java spring based web server
A variation of http clients which are supported

Helps the person to learn about certificates, keystores, ssl commands and basic web security based on certificates.