### PR TITLE
Add TutorialSearch to Educational

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Supported by: [GuardRails.io](https://www.guardrails.io)
 - [BodgeIt Store](https://github.com/psiinon/bodgeit) - A vulnerable web application aimed at people who are new to pen testing.
 - [OWASP Benchmark](https://github.com/OWASP/Benchmark) - A Java test suite designed to verify the speed and accuracy of vulnerability detection tools.
 - [Security Shepherd](https://github.com/OWASP/SecurityShepherd) - Web and mobile application security training platform.
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/devops-it/java-servers) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [WebGoat](https://github.com/WebGoat/WebGoat) - A deliberately insecure Java Web Application.
 
 ## Articles, Guides & Talks

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Supported by: [GuardRails.io](https://www.guardrails.io)
 - [BodgeIt Store](https://github.com/psiinon/bodgeit) - A vulnerable web application aimed at people who are new to pen testing.
 - [OWASP Benchmark](https://github.com/OWASP/Benchmark) - A Java test suite designed to verify the speed and accuracy of vulnerability detection tools.
 - [Security Shepherd](https://github.com/OWASP/SecurityShepherd) - Web and mobile application security training platform.
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [WebGoat](https://github.com/WebGoat/WebGoat) - A deliberately insecure Java Web Application.
 
 ## Articles, Guides & Talks


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Educational* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/devops-it/java-servers) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/devops-it/java-servers) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.